### PR TITLE
BugFix get_bucket.R for use_https

### DIFF
--- a/R/get_bucket.R
+++ b/R/get_bucket.R
@@ -61,7 +61,7 @@ get_bucket <- function(bucket,
                 key = Sys.getenv("AWS_ACCESS_KEY_ID"), 
                 secret = Sys.getenv("AWS_SECRET_ACCESS_KEY"), 
                 session_token = NULL,
-                use_https = FALSE) 
+                use_https = use_https) 
 
     if (isTRUE(parse_response)) {
         while (


### PR DESCRIPTION
use_https from from function call was not taken to account in forming s3HTTP request. Resulted in error: 'Client sent an HTTP request to an HTTPS server.' I changed s3HTTP(...use_https = FALSE) to s3HTTP(...use_https = use_https).